### PR TITLE
Fixed spelling in README & support for setting root url before callin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ api.get('https://api.test.nordnet.se/next/2/accounts/{accno}', { accno: 12345678
   .then(response => console.log(response));
 ```
 
+### Setting root URL before querying
+
+```js
+import api from 'nordnet-next-api';
+
+api.setConfig({root:'https://api.test.nordnet.se/next/2'});
+
+api.get('/accounts/{accno}', { accno: 123456789 })
+  .then(response => console.log(response));
+```
+
 ### Passing path parameters
 
 ```js
@@ -86,9 +97,10 @@ See tests under `src/__tests__` for more examples.
 
 nordnet-next-api is distributed with a two simple example projects.
 
-First, build the project:
+Before proceeding, install dependencies and build the project:
 
 ```
+npm install
 npm run build
 ```
 
@@ -110,7 +122,7 @@ npm start
 
 ## License
 
-This open source project released by Nordnet is licenced under the MIT licence.
+This Open Source project released by Nordnet is licensed under the MIT license.
 
 
 [api]: https://api.test.nordnet.se/

--- a/examples/client/src/components/Status.jsx
+++ b/examples/client/src/components/Status.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { get } from 'nordnet-next-api';
+import { get, setConfig } from 'nordnet-next-api';
 
 class Status extends React.Component {
 
   componentDidMount() {
-    get('/next/2/')
+    setConfig({root: 'https://api.test.nordnet.se/next/2'});
+    get('/')
       .then(response => this.setState({ status: response }));
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,21 @@ const state = {
 
 const credentials = 'include';
 
+let config = {};
+
+export function setConfig(options) {
+  // Currently supported config options
+  let configKeys = [
+    'root',
+  ];
+
+  for (let key in options) {
+    if (configKeys.indexOf(key) !== -1) {
+      config[key] = options[key];
+    }
+  }
+}
+
 export function get(url, params = {}, headers = {}) {
   const options = {
     url,
@@ -68,6 +83,7 @@ export default {
   post,
   put,
   del,
+  setConfig,
 };
 
 function httpFetch(options) {
@@ -126,6 +142,12 @@ function getPathParams(url) {
 function buildUrl(path, query = '') {
   const queryParams = query.length ? query.join('&') : '';
   const pathContainsQuery = path.indexOf('?') !== -1;
+  const pathContainsProtocol = !!(path.match(/^http(s)?:\/\//));
+
+  let root = '';
+  if (!pathContainsProtocol && typeof config.root !== 'undefined') {
+    root = config.root;
+  }
 
   let delimiter = '';
   if (pathContainsQuery) {
@@ -134,7 +156,7 @@ function buildUrl(path, query = '') {
     delimiter = '?';
   }
 
-  return `${path}${delimiter}${queryParams}`;
+  return `${root}${path}${delimiter}${queryParams}`;
 }
 
 function buildPath(url, params) {


### PR DESCRIPTION
Support for setting root url before calling API using setConfig({root: 'http://something'})

Fixed spelling in README and included instructions for how to use setConfig
