### PR TITLE
Fix no response failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ reports
 .DS_Store
 dist
 lib
+.idea
 coverage

--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,14 @@ function parseContent(response) {
   const contentType = response.headers.get('Content-type');
   const method = isJSON(contentType) ? 'json' : 'text';
 
-  return response[method]().then(data => ({ response, data, status: response.status }));
+  return response[method]()
+    .then(data => ({ response, data, status: response.status }))
+    .catch(error => Promise.reject({
+      response,
+      status: response.status,
+      error: new Error(`fetch unable to parse input, most likely API responded with empty reponse.
+        Original Error: ${error}`)
+    }));
 }
 
 function isJSON(contentType) {


### PR DESCRIPTION
   Sometimes it can happen that API will respond with empty body,
    and you will not get response and status code,
    which is bad, but you get internal Fetch error,
    but it also dousnt help and its only source of confusion.
    So by adding this, catch we can gracefully handle invalid API response
