### PR TITLE
Bugfix - the number zero is a valid parameter in path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -216,7 +216,7 @@ function buildUrl(path, query = '') {
 function isNotValidPath(url, params = {}) {
   return !!(url.match(regUrlParam) || [])
     .map(key => key.replace(/({|})/g, ''))
-    .find(key => !params[key]);
+    .find(key => !params[key] && params[key] !== 0);
 }
 
 function buildPath(url, params) {


### PR DESCRIPTION
```
export const getPortfolioSuggestion = score => ({
  type: SOME_TYPE,
  fetch: {
    method: 'get',
    url: '/api-url/{score}',
    params: {
      score,
    },
  },
});

dispatch(getPortfolioSuggestion(0)); // This always failed and throws "Params object doesn't have all required keys for url"
```

This PR fix so you can send zero as a parameter